### PR TITLE
refactor: centraliza padrões de regex em arquivo de constantes

### DIFF
--- a/app/src/app/core/utils/padroes-validacao.ts
+++ b/app/src/app/core/utils/padroes-validacao.ts
@@ -1,0 +1,5 @@
+export const REGEX_PATTERNS = {
+  email: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/,
+
+  cpf: /^\d{11}$/
+};

--- a/app/src/app/page/cadastra-pessoa/cadastra-pessoa.component.html
+++ b/app/src/app/page/cadastra-pessoa/cadastra-pessoa.component.html
@@ -3,32 +3,35 @@
 <main class="main-container">
   <div class="content-wrapper">
     <mat-card class="register-card mat-elevation-z2">
-      
       <mat-card-content>
         <mat-card-title>Cadastrar Nova Pessoa</mat-card-title>
-        <mat-card-subtitle>Preencha os campos abaixo para registrar uma nova pessoa no sistema.</mat-card-subtitle>
-        <form [formGroup]="cadastroForm" (ngSubmit)="cadastrarPessoa()" class="form-grid">
+        <mat-card-subtitle>
+          Preencha os campos abaixo para registrar uma nova pessoa no sistema.
+        </mat-card-subtitle>
 
-          <!-- Campo Nome -->
+        <form [formGroup]="cadastroForm" (ngSubmit)="cadastrarPessoa()" class="form-grid">
           <mat-form-field appearance="outline">
             <mat-label>Nome Completo</mat-label>
-            <input matInput formControlName="nome" placeholder="Ex: João da Silva">
-            <mat-error *ngIf="cadastroForm.get('nome')?.hasError('required')">Nome é obrigatório.</mat-error>
-            <mat-error *ngIf="cadastroForm.get('nome')?.hasError('minlength')">O nome deve ter no mínimo 3 caracteres.</mat-error>
-          </mat-form-field>
-
-          <!-- Campo CPF -->
-          <mat-form-field appearance="outline">
-            <mat-label>CPF</mat-label>
-            <input matInput formControlName="cpf" mask="000.000.000-00" placeholder="000.000.000-00">
-            <mat-error *ngIf="cadastroForm.get('cpf')?.hasError('required')">CPF é obrigatório.</mat-error>
-            <!-- ✅ NOVA MENSAGEM DE ERRO PARA CPF INCOMPLETO -->
-            <mat-error *ngIf="cadastroForm.get('cpf')?.hasError('minlength')">
-              CPF incompleto. Deve conter 11 dígitos.
+            <input matInput formControlName="nome" placeholder="Ex: João da Silva" />
+            <mat-error *ngIf="cadastroForm.get('nome')?.hasError('required')">
+              Nome é obrigatório.
+            </mat-error>
+            <mat-error *ngIf="cadastroForm.get('nome')?.hasError('minlength')">
+              O nome deve ter no mínimo 3 caracteres.
             </mat-error>
           </mat-form-field>
 
-          <!-- Campo Sexo -->
+          <mat-form-field appearance="outline">
+            <mat-label>CPF</mat-label>
+            <input matInput formControlName="cpf" mask="000.000.000-00" placeholder="000.000.000-00" />
+            <mat-error *ngIf="cadastroForm.get('cpf')?.hasError('required')">
+              CPF é obrigatório.
+            </mat-error>
+            <mat-error *ngIf="cadastroForm.get('cpf')?.hasError('pattern')">
+              Formato de CPF inválido.
+            </mat-error>
+          </mat-form-field>
+
           <mat-form-field appearance="outline">
             <mat-label>Sexo</mat-label>
             <mat-select formControlName="sexo">
@@ -36,23 +39,29 @@
               <mat-option value="feminino">Feminino</mat-option>
               <mat-option value="outro">Outro</mat-option>
             </mat-select>
-            <mat-error *ngIf="cadastroForm.get('sexo')?.hasError('required')">Sexo é obrigatório.</mat-error>
+            <mat-error *ngIf="cadastroForm.get('sexo')?.hasError('required')">
+              Sexo é obrigatório.
+            </mat-error>
           </mat-form-field>
 
-          <!-- Campo E-mail -->
           <mat-form-field appearance="outline">
             <mat-label>E-mail</mat-label>
-            <input matInput formControlName="email" type="email" placeholder="Ex: email@exemplo.com">
-            <mat-error *ngIf="cadastroForm.get('email')?.hasError('required')">E-mail é obrigatório.</mat-error>
-            <mat-error *ngIf="cadastroForm.get('email')?.hasError('pattern')">Formato de e-mail inválido.</mat-error>
+            <input matInput formControlName="email" type="email" placeholder="Ex: email@exemplo.com" />
+            <mat-error *ngIf="cadastroForm.get('email')?.hasError('required')">
+              E-mail é obrigatório.
+            </mat-error>
+            <mat-error *ngIf="cadastroForm.get('email')?.hasError('pattern')">
+              Formato de e-mail inválido.
+            </mat-error>
           </mat-form-field>
 
-          <!-- Campo Telefone -->
           <mat-form-field appearance="outline">
             <mat-label>Telefone</mat-label>
-            <input matInput formControlName="telefone" mask="(00) 0000-0000||(00) 0 0000-0000" placeholder="(00) 99999-9999">
-            <mat-error *ngIf="cadastroForm.get('telefone')?.hasError('required')">Telefone é obrigatório.</mat-error>
-            <!-- ✅ NOVA MENSAGEM DE ERRO PARA TELEFONE INCOMPLETO -->
+            <input matInput formControlName="telefone" mask="(00) 0000-0000||(00) 0 0000-0000"
+              placeholder="(00) 99999-9999" />
+            <mat-error *ngIf="cadastroForm.get('telefone')?.hasError('required')">
+              Telefone é obrigatório.
+            </mat-error>
             <mat-error *ngIf="cadastroForm.get('telefone')?.hasError('minlength')">
               Telefone incompleto.
             </mat-error>
@@ -61,7 +70,8 @@
       </mat-card-content>
 
       <mat-card-actions align="end">
-        <button mat-raised-button color="primary" (click)="cadastrarPessoa()" [disabled]="cadastroForm.invalid || isLoading">
+        <button mat-raised-button color="primary" (click)="cadastrarPessoa()"
+          [disabled]="cadastroForm.invalid || isLoading">
           <div class="button-inner-wrapper">
             <mat-progress-spinner *ngIf="isLoading" mode="indeterminate" diameter="20"></mat-progress-spinner>
             <span *ngIf="!isLoading" class="button-content">

--- a/app/src/app/page/cadastra-pessoa/cadastra-pessoa.component.ts
+++ b/app/src/app/page/cadastra-pessoa/cadastra-pessoa.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { REGEX_PATTERNS } from '../../core/utils/padroes-validacao';
 
 @Component({
   selector: 'app-cadastra-pessoa',
@@ -12,20 +13,16 @@ export class CadastraPessoaComponent {
   public cadastroForm: FormGroup;
   public isLoading: boolean = false;
 
-  // Injetamos o FormBuilder para facilitar a criação do formulário
   constructor(
     private fb: FormBuilder,
     private _snackBar: MatSnackBar
   ) {
-    // Regex para validar e-mail
-    const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
-
-    this.cadastroForm = this.fb.group({
+      this.cadastroForm = this.fb.group({
       nome: ['', [Validators.required, Validators.minLength(3)]],
-      cpf: ['', [Validators.required, Validators.minLength(11), Validators.maxLength(11)]],
+      cpf: ['', [Validators.required, Validators.pattern(REGEX_PATTERNS.cpf)]],
       sexo: ['', [Validators.required]],
-      email: ['', [Validators.required, Validators.pattern(emailRegex)]],
-      telefone: ['', [Validators.required, Validators.minLength(10)]] // (xx) xxxx-xxxx ou (xx) xxxxx-xxxx
+      email: ['', [Validators.required, Validators.pattern(REGEX_PATTERNS.email)]],
+      telefone: ['', [Validators.required, Validators.minLength(10)]]
     });
   }
 


### PR DESCRIPTION
Move os padrões de regex de e-mail e CPF para um arquivo dedicado 'padroes-validacao.ts'.
Isso melhora a organização do código, elimina a duplicação e facilita a reutilização das validações em outros formulários no futuro.