### PR TITLE
feat: adiciona camada de serviço e mock de API

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -20,6 +20,7 @@
     "@angular/platform-browser": "^17.3.0",
     "@angular/platform-browser-dynamic": "^17.3.0",
     "@angular/router": "^17.3.0",
+    "angular-in-memory-web-api": "^0.17.0",
     "ngx-mask": "^19.0.7",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/app/src/app/app.module.ts
+++ b/app/src/app/app.module.ts
@@ -11,6 +11,9 @@ import { CadastraPessoaComponent } from './page/cadastra-pessoa/cadastra-pessoa.
 import { ConsultaPessoaComponent } from './page/consulta-pessoa/consulta-pessoa.component';
 import { ReactiveFormsModule } from '@angular/forms';
 import { NgxMaskDirective, NgxMaskPipe, provideNgxMask } from 'ngx-mask';
+import { HttpClientModule } from '@angular/common/http';
+import { HttpClientInMemoryWebApiModule } from 'angular-in-memory-web-api';
+import { InMemoryDataService } from './core/service/in-memory-data.service';
 
 @NgModule({
   declarations: [
@@ -25,7 +28,11 @@ import { NgxMaskDirective, NgxMaskPipe, provideNgxMask } from 'ngx-mask';
     SharedModule,
     NgxMaskDirective,
     NgxMaskPipe,
-    ReactiveFormsModule
+    ReactiveFormsModule,
+    HttpClientModule,
+    HttpClientInMemoryWebApiModule.forRoot(
+      InMemoryDataService, { dataEncapsulation: false, delay: 500 }
+    )
   ],
   providers: [
     provideAnimationsAsync(),

--- a/app/src/app/core/models/pessoa.interface.ts
+++ b/app/src/app/core/models/pessoa.interface.ts
@@ -1,8 +1,8 @@
 export interface Pessoa {
+  id?: number;
   nome: string;
   cpf: string;
   sexo: string;
   email: string;
   telefone: string;
 }
-

--- a/app/src/app/core/service/in-memory-data.service.ts
+++ b/app/src/app/core/service/in-memory-data.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { InMemoryDbService } from 'angular-in-memory-web-api';
+import { Pessoa } from '../models/pessoa.interface';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class InMemoryDataService implements InMemoryDbService {
+
+  createDb() {
+    const pessoas: Pessoa[] = [
+      {
+        id: 1, 
+        nome: 'Cleber Roger',
+        cpf: '11111111111', 
+        sexo: 'Masculino',
+        email: 'cleber13@exemplo.com',
+        telefone: '11987654321'
+      },
+      {
+        id: 2,
+        nome: 'Sara silva',
+        cpf: '22222222222',
+        sexo: 'Feminino',
+        email: 'sarasa12@exemplo.com',
+        telefone: '21912345678'
+      }
+    ];
+    return { pessoas };
+  }
+
+  genId(pessoas: Pessoa[]): number {
+    return pessoas.length > 0 ? Math.max(...pessoas.map(p => p.id as number)) + 1 : 11;
+  }
+}

--- a/app/src/app/page/cadastra-pessoa/cadastra-pessoa.component.ts
+++ b/app/src/app/page/cadastra-pessoa/cadastra-pessoa.component.ts
@@ -2,6 +2,9 @@ import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { REGEX_PATTERNS } from '../../core/utils/padroes-validacao';
+import { PessoasService } from '../../service/pessoas.service';
+import { finalize } from 'rxjs';
+import { Pessoa } from '../../core/models/pessoa.interface';
 
 @Component({
   selector: 'app-cadastra-pessoa',
@@ -15,7 +18,8 @@ export class CadastraPessoaComponent {
 
   constructor(
     private fb: FormBuilder,
-    private _snackBar: MatSnackBar
+    private matSnackbar: MatSnackBar,
+    private pessoasService: PessoasService
   ) {
       this.cadastroForm = this.fb.group({
       nome: ['', [Validators.required, Validators.minLength(3)]],
@@ -28,27 +32,42 @@ export class CadastraPessoaComponent {
 
   cadastrarPessoa(): void {
     if (this.cadastroForm.invalid) {
-      // Marca todos os campos como "tocados" para exibir os erros de validação
       this.cadastroForm.markAllAsTouched();
       return;
     }
 
     this.isLoading = true;
+    const novaPessoa = this.cadastroForm.value as Pessoa;
 
-    // SIMULAÇÃO DE ENVIO PARA A API
-    setTimeout(() => {
-      console.log('Dados do formulário:', this.cadastroForm.value);
-      this.isLoading = false;
-      this.exibirMensagemSucesso('Pessoa cadastrada com sucesso!');
-      this.cadastroForm.reset(); // Limpa o formulário após o sucesso
-    }, 2000);
+    this.pessoasService.cadastrarPessoa(novaPessoa).pipe(
+      finalize(() => this.isLoading = false)
+    ).subscribe({
+      next: (pessoaCadastrada) => {
+        console.log('API retornou:', pessoaCadastrada);
+        this.exibirMensagemSucesso('Pessoa cadastrada com sucesso!');
+        this.cadastroForm.reset();
+      },
+      error: (err) => {
+        this.exibirMensagemErro('Ocorreu um erro ao cadastrar.');
+        console.error(err);
+      }
+    });
   }
 
   exibirMensagemSucesso(mensagem: string): void {
-    this._snackBar.open(mensagem, 'OK', {
+    this.matSnackbar.open(mensagem, 'OK', {
       duration: 3000,
       verticalPosition: 'top',
       horizontalPosition: 'center',
     });
   }
+
+  exibirMensagemErro(mensagem: string): void {
+    this.matSnackbar.open(mensagem, 'Fechar', {
+      duration: 5000,
+      verticalPosition: 'top',
+      horizontalPosition: 'center',
+    });
+  }
+
 }

--- a/app/src/app/service/pessoas.service.spec.ts
+++ b/app/src/app/service/pessoas.service.spec.ts
@@ -1,0 +1,16 @@
+/* tslint:disable:no-unused-variable */
+
+import { TestBed, async, inject } from '@angular/core/testing';
+import { PessoasService } from './pessoas.service';
+
+describe('Service: Pessoas', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [PessoasService]
+    });
+  });
+
+  it('should ...', inject([PessoasService], (service: PessoasService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/app/src/app/service/pessoas.service.ts
+++ b/app/src/app/service/pessoas.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
+import { Pessoa } from '../core/models/pessoa.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PessoasService {
+
+  private apiUrl = 'api/pessoas';
+
+  constructor(private http: HttpClient) { }
+
+  buscarPessoaPorCpf(cpf: string): Observable<Pessoa> {
+    const url = `${this.apiUrl}/?cpf=${cpf}`;
+    
+    return this.http.get<Pessoa[]>(url).pipe(
+      map(pessoas => {
+        if (pessoas.length > 0) {
+          return pessoas[0];
+        }
+        throw new Error('Pessoa não encontrada');
+      }),
+      catchError(this.handleError)
+    );
+  }
+
+  cadastrarPessoa(novaPessoa: Pessoa): Observable<Pessoa> {
+    return this.http.post<Pessoa>(this.apiUrl, novaPessoa).pipe(
+      catchError(this.handleError)
+    );
+  }
+
+  private handleError(error: HttpErrorResponse) {
+    let errorMessage = 'Ocorreu um erro desconhecido!';
+    if (error.error instanceof ErrorEvent) {
+      errorMessage = `Um erro ocorreu: ${error.error.message}`;
+    } else {
+      errorMessage = `Código do erro: ${error.status}, mensagem: ${error.message}`;
+    }
+    console.error(errorMessage);
+    return throwError(() => new Error('Algo deu errado; por favor, tente novamente mais tarde.'));
+  }
+}


### PR DESCRIPTION
Cria o PessoasService para centralizar toda a lógica de acesso a dados.
Instala e configura a biblioteca Angular In-Memory Web API para simular um backend.
Cria o InMemoryDataService para servir como um banco de dados falso em memória.
Refatora os componentes de consulta e cadastro para injetar e usar o PessoasService.
Substitui a lógica de `setTimeout` por chamadas HTTP reais (GET/POST) via HttpClient e Observables.